### PR TITLE
Adding delete basket logic on basket list and parts pages. New modal to confirm delete

### DIFF
--- a/pages/popup/public/horizontaldots.svg
+++ b/pages/popup/public/horizontaldots.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 12H18.01M12 12H12.01M6 12H6.01M13 12C13 12.5523 12.5523 13 12 13C11.4477 13 11 12.5523 11 12C11 11.4477 11.4477 11 12 11C12.5523 11 13 11.4477 13 12ZM19 12C19 12.5523 18.5523 13 18 13C17.4477 13 17 12.5523 17 12C17 11.4477 17.4477 11 18 11C18.5523 11 19 11.4477 19 12ZM7 12C7 12.5523 6.55228 13 6 13C5.44772 13 5 12.5523 5 12C5 11.4477 5.44772 11 6 11C6.55228 11 7 11.4477 7 12Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/pages/popup/public/leftarrow.svg
+++ b/pages/popup/public/leftarrow.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 12L17 12M7 12L11 8M7 12L11 16" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/pages/popup/public/trash.svg
+++ b/pages/popup/public/trash.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 10V16M14 10V16M18 6V18C18 19.1046 17.1046 20 16 20H8C6.89543 20 6 19.1046 6 18V6M4 6H20M15 6V5C15 3.89543 14.1046 3 13 3H11C9.89543 3 9 3.89543 9 5V6" stroke="#000000" fill="#FFACAC" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/pages/popup/src/Basket.tsx
+++ b/pages/popup/src/Basket.tsx
@@ -1,31 +1,84 @@
 import '@src/Popup.css';
 import { withErrorBoundary, withSuspense } from '@extension/shared';
+import { useState, useEffect, useRef } from 'react';
 import type { IBasket, NavigateToViewFunction } from '../../../chrome-extension/public/types';
 import { ViewOptions } from '../../../chrome-extension/public/enums';
+import BasketOptions from '@src/BasketOptions';
 
-const Basket = ({ basket, navigateToView }: { basket: IBasket; navigateToView: NavigateToViewFunction }) => {
+const Basket = ({
+  basket,
+  navigateToView,
+  deleteBasket,
+}: {
+  basket: IBasket;
+  navigateToView: NavigateToViewFunction;
+  deleteBasket: (basketId: string) => void;
+}) => {
+  const [showBasketOptions, setShowBasketOptions] = useState(false);
+  const optionsRef = useRef<HTMLDivElement>(null);
   const navigateToPartsView = () => navigateToView(ViewOptions.PARTS_VIEW, basket.id);
 
+  useEffect(() => {
+    if (!showBasketOptions) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        e.button == 0 &&
+        optionsRef.current &&
+        !optionsRef.current.contains(e.target as Node) &&
+        (e.target as HTMLElement).id !== 'delete-basket-button'
+      ) {
+        setShowBasketOptions(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [showBasketOptions]);
+
+  const deleteBasketHandler = () => {
+    setShowBasketOptions(false);
+    deleteBasket(basket.id);
+  };
+
   return (
-    <div
-      className={`basket-row`}
-      onClick={navigateToPartsView}
-      role="button"
-      tabIndex={0}
-      onKeyDown={e => {
-        if (e.key === 'Enter') {
-          navigateToPartsView();
-        }
-      }}>
-      <div className={`w-2/5 flex-none px-1`}>{basket.name}</div>
-      <div className={`w-1/5 flex-none`}>{Object.keys(basket.partList).length} parts</div>
-      <div className={`w-1/5 flex-none`}>
-        {/* TODO: disable button if we are not on a lizzy page */}
-        <button className={`import-button`} onClick={e => importBasket(e, basket)}>
-          Import
-        </button>
+    <div className="relative">
+      <div
+        className={`basket-row basket-row-container`}
+        onClick={navigateToPartsView}
+        role="button"
+        tabIndex={0}
+        onKeyDown={e => {
+          if (e.key === 'Enter') {
+            navigateToPartsView();
+          }
+        }}>
+        <div className={`w-2/5 flex-none px-1`}>{basket.name}</div>
+        <div className={`w-1/5 flex-none`}>{Object.keys(basket.partList).length} parts</div>
+        <div className={`w-1/5 flex-none`}>
+          {/* TODO: disable button if we are not on a lizzy page */}
+          <button className={`import-button`} onClick={e => importBasket(e, basket)}>
+            Import
+          </button>
+        </div>
+        <div ref={optionsRef} className="w-1/5 flex flex-none justify-center">
+          <button
+            className="dots-button"
+            onClick={e => {
+              e.stopPropagation();
+              setShowBasketOptions(!showBasketOptions);
+            }}>
+            <img
+              src="horizontaldots.svg"
+              alt="horizontal dots"
+              width="30"
+              height="20"
+              className="fill-current hover:bg-gray-100"
+            />
+          </button>
+        </div>
       </div>
-      <div className={`w-1/5 flex-none text-right text-lg font-bold pr-1`}>{'>'}</div>
+      {showBasketOptions && <BasketOptions deleteBasket={deleteBasketHandler} />}
     </div>
   );
 };

--- a/pages/popup/src/Basket.tsx
+++ b/pages/popup/src/Basket.tsx
@@ -9,10 +9,12 @@ const Basket = ({
   basket,
   navigateToView,
   deleteBasket,
+  tabId,
 }: {
   basket: IBasket;
   navigateToView: NavigateToViewFunction;
   deleteBasket: (basketId: string) => void;
+  tabId: number;
 }) => {
   const [showBasketOptions, setShowBasketOptions] = useState(false);
   const optionsRef = useRef<HTMLDivElement>(null);
@@ -56,8 +58,11 @@ const Basket = ({
         <div className={`w-2/5 flex-none px-1`}>{basket.name}</div>
         <div className={`w-1/5 flex-none`}>{Object.keys(basket.partList).length} parts</div>
         <div className={`w-1/5 flex-none`}>
-          {/* TODO: disable button if we are not on a lizzy page */}
-          <button className={`import-button`} onClick={e => importBasket(e, basket)}>
+          <button
+            className="import-button"
+            type="button"
+            disabled={tabId === 0}
+            onClick={e => importBasket(e, { tabId, basket })}>
             Import
           </button>
         </div>
@@ -83,24 +88,19 @@ const Basket = ({
   );
 };
 
-const importBasket = async (e: React.MouseEvent, basket: IBasket) => {
+const importBasket = async (e: React.MouseEvent, { tabId, basket }: { tabId: number; basket: IBasket }) => {
   e.stopPropagation();
+  if (tabId === 0) {
+    return;
+  }
   console.log(`importing basket: ${basket}`);
 
-  const validUrls = ['https://*.nizex.com/'];
   try {
-    const [tab] = await chrome.tabs.query({ active: true, url: validUrls });
-
-    if (!tab || !tab.id) {
-      console.error('No Lizzy tab found');
-      return;
-    }
-
     const importBasketMessage = {
       type: 'IMPORT_BASKET',
       basket,
     };
-    const response = await chrome.tabs.sendMessage(tab.id, importBasketMessage);
+    const response = await chrome.tabs.sendMessage(tabId, importBasketMessage);
 
     // AP: TODO: add messaging when basket is successfully or unsuccessfully imported
     if (response?.success) {

--- a/pages/popup/src/Basket.tsx
+++ b/pages/popup/src/Basket.tsx
@@ -24,12 +24,7 @@ const Basket = ({
     if (!showBasketOptions) return;
 
     const handleClickOutside = (e: MouseEvent) => {
-      if (
-        e.button == 0 &&
-        optionsRef.current &&
-        !optionsRef.current.contains(e.target as Node) &&
-        (e.target as HTMLElement).id !== 'delete-basket-button'
-      ) {
+      if (e.button == 0 && optionsRef.current && !optionsRef.current.contains(e.target as Node)) {
         setShowBasketOptions(false);
       }
     };
@@ -37,11 +32,6 @@ const Basket = ({
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [showBasketOptions]);
-
-  const deleteBasketHandler = () => {
-    setShowBasketOptions(false);
-    deleteBasket(basket.id);
-  };
 
   return (
     <div className="relative">
@@ -66,24 +56,26 @@ const Basket = ({
             Import
           </button>
         </div>
-        <div ref={optionsRef} className="w-1/5 flex flex-none justify-center">
-          <button
-            className="dots-button"
-            onClick={e => {
-              e.stopPropagation();
-              setShowBasketOptions(!showBasketOptions);
-            }}>
-            <img
-              src="horizontaldots.svg"
-              alt="horizontal dots"
-              width="30"
-              height="20"
-              className="fill-current hover:bg-gray-100"
-            />
-          </button>
+        <div ref={optionsRef} className="w-1/5 relative">
+          <div className="w-full flex flex-none justify-center">
+            <button
+              className="dots-button"
+              onClick={e => {
+                e.stopPropagation();
+                setShowBasketOptions(!showBasketOptions);
+              }}>
+              <img
+                src="horizontaldots.svg"
+                alt="horizontal dots"
+                width="30"
+                height="20"
+                className="fill-current hover:bg-gray-100"
+              />
+            </button>
+          </div>
+          {showBasketOptions && <BasketOptions deleteBasket={deleteBasket} basket={basket} />}
         </div>
       </div>
-      {showBasketOptions && <BasketOptions deleteBasket={deleteBasketHandler} />}
     </div>
   );
 };

--- a/pages/popup/src/BasketOptions.tsx
+++ b/pages/popup/src/BasketOptions.tsx
@@ -1,0 +1,20 @@
+import '@src/Popup.css';
+import { withErrorBoundary, withSuspense } from '@extension/shared';
+
+const BasketOptions = ({ deleteBasket }: { deleteBasket: () => void }) => {
+  return (
+    <div className="absolute right-0 w-28 bg-white bg-gray-800 border border-gray-200 border-gray-700 rounded shadow-lg z-10">
+      <button
+        id="delete-basket-button"
+        onClick={e => {
+          e.stopPropagation();
+          deleteBasket();
+        }}
+        className="w-full text-left px-3 py-2 text-sm text-[#ff2626] hover:bg-gray-100 rounded flex">
+        <img src="trash.svg" alt="trash" width="20" height="20" className="inline" /> Delete
+      </button>
+    </div>
+  );
+};
+
+export default withErrorBoundary(withSuspense(BasketOptions, <div> Loading ... </div>), <div> Error Occur </div>);

--- a/pages/popup/src/BasketOptions.tsx
+++ b/pages/popup/src/BasketOptions.tsx
@@ -1,18 +1,26 @@
 import '@src/Popup.css';
 import { withErrorBoundary, withSuspense } from '@extension/shared';
+import { useState } from 'react';
+import Modal from '@src/Modal';
+import type { IBasket } from '../../../chrome-extension/public/types';
 
-const BasketOptions = ({ deleteBasket }: { deleteBasket: () => void }) => {
+const BasketOptions = ({ deleteBasket, basket }: { deleteBasket: (basketId: string) => void; basket: IBasket }) => {
+  const [showModal, setShowModal] = useState(false);
+
   return (
     <div className="absolute right-0 w-28 bg-white bg-gray-800 border border-gray-200 border-gray-700 rounded shadow-lg z-10">
       <button
         id="delete-basket-button"
         onClick={e => {
           e.stopPropagation();
-          deleteBasket();
+          setShowModal(true);
         }}
         className="w-full text-left px-3 py-2 text-sm text-[#ff2626] hover:bg-gray-100 rounded flex">
         <img src="trash.svg" alt="trash" width="20" height="20" className="inline" /> Delete
       </button>
+      {showModal && (
+        <Modal deleteBasket={deleteBasket} setShowModal={setShowModal} basketId={basket.id} basketName={basket.name} />
+      )}
     </div>
   );
 };

--- a/pages/popup/src/BasketTable.tsx
+++ b/pages/popup/src/BasketTable.tsx
@@ -8,14 +8,18 @@ const BasketTable = ({
   basketsById,
   navigateToView,
   filterText,
+  deleteBasket,
 }: {
   basketsById: Record<string, IBasket>;
   navigateToView: NavigateToViewFunction;
   filterText: string;
+  deleteBasket: (basketId: string) => void;
 }) => {
   const basketList = Object.values(basketsById).reduce((basketList, basket: IBasket) => {
     if (basket.name.toLowerCase().includes(filterText)) {
-      basketList.push(<Basket key={basket.id} basket={basket} navigateToView={navigateToView} />);
+      basketList.push(
+        <Basket key={basket.id} basket={basket} navigateToView={navigateToView} deleteBasket={deleteBasket} />,
+      );
     }
 
     return basketList;

--- a/pages/popup/src/BasketTable.tsx
+++ b/pages/popup/src/BasketTable.tsx
@@ -9,16 +9,24 @@ const BasketTable = ({
   navigateToView,
   filterText,
   deleteBasket,
+  tabId,
 }: {
   basketsById: Record<string, IBasket>;
   navigateToView: NavigateToViewFunction;
   filterText: string;
   deleteBasket: (basketId: string) => void;
+  tabId: number;
 }) => {
   const basketList = Object.values(basketsById).reduce((basketList, basket: IBasket) => {
     if (basket.name.toLowerCase().includes(filterText)) {
       basketList.push(
-        <Basket key={basket.id} basket={basket} navigateToView={navigateToView} deleteBasket={deleteBasket} />,
+        <Basket
+          key={basket.id}
+          basket={basket}
+          navigateToView={navigateToView}
+          deleteBasket={deleteBasket}
+          tabId={tabId}
+        />,
       );
     }
 

--- a/pages/popup/src/Footer.tsx
+++ b/pages/popup/src/Footer.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import '@src/Popup.css';
+import Modal from '@src/Modal';
+import { withErrorBoundary, withSuspense } from '@extension/shared';
+import type { IBasket } from '../../../chrome-extension/public/types';
+
+const Footer = ({ basket, deleteBasket }: { basket: IBasket; deleteBasket: (basketId: string) => void }) => {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <div className={`flex py-1`}>
+      <div className={`w-1/5 flex-none px-1`}>
+        <button className={`bg-[#FFACAC] hover:bg-[#E49999] px-4 py-2 rounded`} onClick={() => setShowModal(true)}>
+          Delete
+        </button>
+      </div>
+
+      {showModal && (
+        <Modal deleteBasket={deleteBasket} setShowModal={setShowModal} basketId={basket.id} basketName={basket.name} />
+      )}
+    </div>
+  );
+};
+
+export default withErrorBoundary(withSuspense(Footer, <div> Loading ... </div>), <div> Error Occur </div>);

--- a/pages/popup/src/Header.tsx
+++ b/pages/popup/src/Header.tsx
@@ -5,15 +5,13 @@ import { ViewOptions } from '../../../chrome-extension/public/enums';
 
 const Header = ({ header, navigateToView }: { header: string; navigateToView: NavigateToViewFunction }) => {
   return (
-    <div className={`flex py-1`}>
-      <div className={`w-1/5 flex-none px-1`}>
-        <button
-          className={`bg-[#ACC5FD] hover:bg-[#9EB0DB] px-2 py-1 rounded`}
-          onClick={() => navigateToView(ViewOptions.BASKET_VIEW)}>
-          Back
-        </button>
-      </div>
-      <div className={`w-4/5 flex-none text-base text-center`}>{header}</div>
+    <div className={`relative flex items-center py-1`}>
+      <button
+        className={`absolute left-1 top-1/2 -translate-y-[45%] bg-[#ACC5FD] px-2 py-1 rounded hover:bg-[#9EB0DB]`}
+        onClick={() => navigateToView(ViewOptions.BASKET_VIEW)}>
+        <img src="leftarrow.svg" alt="left arrow" width="20" height="20" className="fill-current hover:bg-[#9EB0DB]" />
+      </button>
+      <div className={`w-full px-10 text-base text-center`}>{header}</div>
     </div>
   );
 };

--- a/pages/popup/src/Modal.tsx
+++ b/pages/popup/src/Modal.tsx
@@ -16,7 +16,10 @@ const Modal = ({
     <div className={`flex py-1`}>
       <div
         className="modal-overlay"
-        onClick={() => setShowModal(false)}
+        onClick={e => {
+          e.stopPropagation();
+          setShowModal(false);
+        }}
         role="button"
         tabIndex={0}
         onKeyDown={e => {
@@ -40,14 +43,14 @@ const Modal = ({
           <div className="flex justify-center gap-3">
             <button
               className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300 text-gray-800"
-              onClick={() => setShowModal(false)}>
-              tabIndex={0}
+              onClick={() => setShowModal(false)}
+              tabIndex={0}>
               Cancel
             </button>
             <button
               className="px-4 py-2 rounded bg-red-500 hover:bg-red-600 text-white"
-              onClick={() => deleteBasket(basketId)}>
-              tabIndex={0}
+              onClick={() => deleteBasket(basketId)}
+              tabIndex={0}>
               Confirm
             </button>
           </div>

--- a/pages/popup/src/Modal.tsx
+++ b/pages/popup/src/Modal.tsx
@@ -1,0 +1,40 @@
+import '@src/Popup.css';
+import { withErrorBoundary, withSuspense } from '@extension/shared';
+
+const Modal = ({
+  deleteBasket,
+  setShowModal,
+  basketName,
+  basketId,
+}: {
+  deleteBasket: (basketId: string) => void;
+  setShowModal: (showModal: boolean) => void;
+  basketName: string;
+  basketId: string;
+}) => {
+  return (
+    <div className={`flex py-1`}>
+      <div className="modal-overlay" onClick={() => setShowModal(false)}>
+        <div className="modal-content" onClick={e => e.stopPropagation()}>
+          <p className="text-gray-800 text-base mb-6">
+            Are you sure you want to delete <b>{basketName}</b>?
+          </p>
+          <div className="flex justify-center gap-3">
+            <button
+              className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300 text-gray-800"
+              onClick={() => setShowModal(false)}>
+              Cancel
+            </button>
+            <button
+              className="px-4 py-2 rounded bg-red-500 hover:bg-red-600 text-white"
+              onClick={() => deleteBasket(basketId)}>
+              Confirm
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default withErrorBoundary(withSuspense(Modal, <div> Loading ... </div>), <div> Error Occur </div>);

--- a/pages/popup/src/Modal.tsx
+++ b/pages/popup/src/Modal.tsx
@@ -14,8 +14,26 @@ const Modal = ({
 }) => {
   return (
     <div className={`flex py-1`}>
-      <div className="modal-overlay" onClick={() => setShowModal(false)}>
-        <div className="modal-content" onClick={e => e.stopPropagation()}>
+      <div
+        className="modal-overlay"
+        onClick={() => setShowModal(false)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={e => {
+          if (e.key === 'Enter') {
+            setShowModal(false);
+          }
+        }}>
+        <div
+          className="modal-content"
+          onClick={e => e.stopPropagation()}
+          role="button"
+          tabIndex={0}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              e.stopPropagation();
+            }
+          }}>
           <p className="text-gray-800 text-base mb-6">
             Are you sure you want to delete <b>{basketName}</b>?
           </p>
@@ -23,11 +41,13 @@ const Modal = ({
             <button
               className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300 text-gray-800"
               onClick={() => setShowModal(false)}>
+              tabIndex={0}
               Cancel
             </button>
             <button
               className="px-4 py-2 rounded bg-red-500 hover:bg-red-600 text-white"
               onClick={() => deleteBasket(basketId)}>
+              tabIndex={0}
               Confirm
             </button>
           </div>

--- a/pages/popup/src/Part.tsx
+++ b/pages/popup/src/Part.tsx
@@ -8,7 +8,6 @@ const Part = ({ part }: { part: IPart }) => {
       <div className={`w-2/5 flex-none px-1`}>{part.number}</div>
       <div className={`w-2/5 flex-none`}>{part.description}</div>
       <div className={`w-1/5 flex-none`}>{part.quantity}</div>
-      {/* TODO: add a delete/trash button */}
     </div>
   );
 };

--- a/pages/popup/src/PartTable.tsx
+++ b/pages/popup/src/PartTable.tsx
@@ -4,15 +4,18 @@ import type { IBasket, IPart, NavigateToViewFunction } from '../../../chrome-ext
 import Part from '@src/Part';
 import Header from '@src/Header';
 import SubHeader from '@src/SubHeader';
+import Footer from '@src/Footer';
 
 const PartTable = ({
   basket,
   navigateToView,
   filterText,
+  deleteBasket,
 }: {
   basket: IBasket;
   navigateToView: NavigateToViewFunction;
   filterText: string;
+  deleteBasket: (basketId: string) => void;
 }) => {
   const partList = basket.partList.reduce((partList, part: IPart) => {
     if (part.number.toLowerCase().includes(filterText) || part.description.toLowerCase().includes(filterText)) {
@@ -26,6 +29,7 @@ const PartTable = ({
       <Header header={basket.name} navigateToView={navigateToView}></Header>
       <SubHeader header1={'Part No.'} header2={'Part Desc.'} header3={'Qty'}></SubHeader>
       <div className={'h-[400px] overflow-auto'}>{partList}</div>
+      <Footer basket={basket} deleteBasket={deleteBasket}></Footer>
     </div>
   );
 };

--- a/pages/popup/src/Popup.css
+++ b/pages/popup/src/Popup.css
@@ -29,10 +29,22 @@ code {
   padding: 0.2rem 0.5rem;
 }
 
+.basket-row-container:hover:not(:has(.dots-button:hover)) {
+  @apply bg-gray-100;
+}
+
 .basket-row {
-  @apply flex py-1 text-sm hover:bg-gray-100;
+  @apply flex py-1 text-sm items-center;
 }
 
 .import-button {
   @apply bg-[#ACC5FD] hover:bg-[#9EB0DB] px-2 py-1 rounded;
+}
+
+.modal-overlay {
+  @apply fixed inset-0 bg-black/50 flex items-center justify-center z-50;
+}
+
+.modal-content {
+  @apply bg-white rounded-lg p-6 shadow-lg max-w-sm w-full mx-4;
 }

--- a/pages/popup/src/Popup.css
+++ b/pages/popup/src/Popup.css
@@ -41,6 +41,10 @@ code {
   @apply bg-[#ACC5FD] hover:bg-[#9EB0DB] px-2 py-1 rounded;
 }
 
+.import-button:disabled {
+  @apply cursor-not-allowed bg-slate-300 text-slate-500 opacity-80 hover:bg-slate-300;
+}
+
 .modal-overlay {
   @apply fixed inset-0 bg-black/50 flex items-center justify-center z-50;
 }

--- a/pages/popup/src/Popup.tsx
+++ b/pages/popup/src/Popup.tsx
@@ -7,16 +7,18 @@ import SearchBar from '@src/SearchBar';
 import type { IBasket } from '../../../chrome-extension/public/types';
 import { ViewOptions } from '../../../chrome-extension/public/enums';
 
-let basketsById: Record<string, IBasket> = {};
+let currentBaskets: Record<string, IBasket> = {};
 const getBaskets = async () => {
   const { baskets } = await chrome.storage.local.get('baskets');
-  basketsById = baskets || {};
+  currentBaskets = baskets || {};
 };
 getBaskets();
+
 const Popup = () => {
   const [currentView, setCurrentView] = useState<ViewOptions>(ViewOptions.BASKET_VIEW);
   const [selectedBasketId, setSelectedBasketId] = useState<string>('');
   const [filterText, setFilterText] = useState<string>('');
+  const [basketsById, setBasketsById] = useState<Record<string, IBasket>>(currentBaskets);
 
   const navigateToView = (view: ViewOptions, basketId?: string) => {
     setFilterText('');
@@ -24,17 +26,38 @@ const Popup = () => {
     setSelectedBasketId(basketId || '');
   };
 
+  const deleteBasket = async (basketId: string) => {
+    const { baskets } = await chrome.storage.local.get('baskets');
+    delete baskets[basketId];
+    setBasketsById(baskets);
+
+    await chrome.storage.local.set({ baskets: baskets });
+
+    if (currentView !== ViewOptions.BASKET_VIEW) {
+      navigateToView(ViewOptions.BASKET_VIEW);
+    }
+  };
+
   console.log('basketsById', Object.values(basketsById));
   return (
     <div>
-      {/* TODO: implement search bar logic for parts and baskets, this is just the back button for now */}
       <SearchBar setFilterText={setFilterText}></SearchBar>
       {/* TODO: tabs to switch between saved baskets and potential settings page */}
       {currentView == ViewOptions.BASKET_VIEW && (
-        <BasketTable basketsById={basketsById} navigateToView={navigateToView} filterText={filterText} />
+        <BasketTable
+          basketsById={basketsById}
+          navigateToView={navigateToView}
+          filterText={filterText}
+          deleteBasket={deleteBasket}
+        />
       )}
       {currentView == ViewOptions.PARTS_VIEW && (
-        <PartTable basket={basketsById[selectedBasketId]} navigateToView={navigateToView} filterText={filterText} />
+        <PartTable
+          basket={basketsById[selectedBasketId]}
+          navigateToView={navigateToView}
+          filterText={filterText}
+          deleteBasket={deleteBasket}
+        />
       )}
     </div>
   );

--- a/pages/popup/src/Popup.tsx
+++ b/pages/popup/src/Popup.tsx
@@ -30,15 +30,15 @@ const Popup = () => {
   };
 
   const deleteBasket = async (basketId: string) => {
+    if (currentView !== ViewOptions.BASKET_VIEW) {
+      navigateToView(ViewOptions.BASKET_VIEW);
+    }
+
     const { baskets } = await chrome.storage.local.get('baskets');
     delete baskets[basketId];
     setBasketsById(baskets);
 
     await chrome.storage.local.set({ baskets: baskets });
-
-    if (currentView !== ViewOptions.BASKET_VIEW) {
-      navigateToView(ViewOptions.BASKET_VIEW);
-    }
   };
 
   console.log('basketsById', Object.values(basketsById));

--- a/pages/popup/src/Popup.tsx
+++ b/pages/popup/src/Popup.tsx
@@ -1,24 +1,27 @@
 import '@src/Popup.css';
 import { withErrorBoundary, withSuspense } from '@extension/shared';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import BasketTable from '@src/BasketTable';
 import PartTable from '@src/PartTable';
 import SearchBar from '@src/SearchBar';
 import type { IBasket } from '../../../chrome-extension/public/types';
 import { ViewOptions } from '../../../chrome-extension/public/enums';
 
-let currentBaskets: Record<string, IBasket> = {};
-const getBaskets = async () => {
-  const { baskets } = await chrome.storage.local.get('baskets');
-  currentBaskets = baskets || {};
-};
-getBaskets();
+let tabId: number = 0;
 
 const Popup = () => {
   const [currentView, setCurrentView] = useState<ViewOptions>(ViewOptions.BASKET_VIEW);
   const [selectedBasketId, setSelectedBasketId] = useState<string>('');
   const [filterText, setFilterText] = useState<string>('');
-  const [basketsById, setBasketsById] = useState<Record<string, IBasket>>(currentBaskets);
+  const [basketsById, setBasketsById] = useState<Record<string, IBasket>>({});
+
+  useEffect(() => {
+    chrome.storage.local.get('baskets').then(({ baskets }) => {
+      setBasketsById(baskets || {});
+    });
+
+    chrome.tabs.query({ active: true, url: ['https://*.nizex.com/*'] }).then(([tab]) => (tabId = tab?.id ?? 0));
+  }, []);
 
   const navigateToView = (view: ViewOptions, basketId?: string) => {
     setFilterText('');
@@ -49,6 +52,7 @@ const Popup = () => {
           navigateToView={navigateToView}
           filterText={filterText}
           deleteBasket={deleteBasket}
+          tabId={tabId}
         />
       )}
       {currentView == ViewOptions.PARTS_VIEW && (


### PR DESCRIPTION
Adding logic to allow deleting of a basket from the extension to both the individual basket components and on the parts table component.
New modal added to confirm user wants to delete the basket when deleting.
Update to formatting of Parts Table header to ensure it's centered.
Added new SVGs for various buttons to indicate options are available.
Getting basket info and checking if Lizzy tab when popup first loaded.
Disabling import button when not on Lizzy site